### PR TITLE
在运行flutter build ios 会出现如下错误

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
     - QQSDK
   - image_picker (0.0.1):
     - Flutter
-  - QQSDK (3.3.1)
+  - QQSDK (3.3.3)
 
 DEPENDENCIES:
-  - Flutter (from `.symlinks/flutter/ios`)
+  - Flutter (from `.symlinks/flutter/ios-release`)
   - flutter_qq (from `.symlinks/plugins/flutter_qq/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
 
@@ -18,7 +18,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Flutter:
-    :path: ".symlinks/flutter/ios"
+    :path: ".symlinks/flutter/ios-release"
   flutter_qq:
     :path: ".symlinks/plugins/flutter_qq/ios"
   image_picker:
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
-  flutter_qq: c9de12c3b1064e11a093630a43d13cb7db4d44cb
+  flutter_qq: fd560988a312c5c7c077f1f93980badf1de09eed
   image_picker: 16e5fec1fbc87fd3b297c53e4048521eaf17cd06
-  QQSDK: 2bb36f564c4771c3092ba9b7e6874651bf179656
+  QQSDK: 97a38fdbd3217626f0ef16321b67c4eb67e7bf9d
 
 PODFILE CHECKSUM: 1e5af4103afd21ca5ead147d7b81d06f494f51a2
 
-COCOAPODS: 1.6.0
+COCOAPODS: 1.7.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				F3CBC2390FE5EA8578AE3FDA /* [CP] Embed Pods Frameworks */,
+				3D613EDE37FD2BDA1FAD0917 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -183,7 +183,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 9669FXNYQX;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -197,6 +196,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -239,7 +239,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin\n";
+		};
+		3D613EDE37FD2BDA1FAD0917 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		64F1E4791E29623DE60DBD7B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -271,25 +289,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		F3CBC2390FE5EA8578AE3FDA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -434,7 +434,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9669FXNYQX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -458,7 +458,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9669FXNYQX;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Classes/FlutterQqPlugin.h
+++ b/ios/Classes/FlutterQqPlugin.h
@@ -1,7 +1,4 @@
 #import <Flutter/Flutter.h>
-#import <TencentOpenAPI/TencentOAuth.h>
-#import <TencentOpenAPI/QQApiInterface.h>
-#import <TencentOpenAPI/QQApiInterfaceObject.h>
 
 #define SHARE_TO_QQ_TYPE_DEFAULT 1 // 默认（图片文字） news
 #define SHARE_TO_QZONE_TYPE_IMAGE_TEXT 1 // 图片文字 news

--- a/ios/Classes/FlutterQqPlugin.m
+++ b/ios/Classes/FlutterQqPlugin.m
@@ -1,4 +1,7 @@
 #import "FlutterQqPlugin.h"
+#import <TencentOpenAPI/TencentOAuth.h>
+#import <TencentOpenAPI/QQApiInterface.h>
+#import <TencentOpenAPI/QQApiInterfaceObject.h>
 
 @interface FlutterQqPlugin()<QQApiInterfaceDelegate, TencentSessionDelegate> {
     TencentOAuth* _oauth;


### PR DESCRIPTION
在运行flutter build ios的时候会出现如下的错误，

> ` While building module 'flutter_qq' imported from 
GeneratedPluginRegistrant.m:9:
    In file included from <module-includes>:1:
    In file included from  build/ios/Release-iphoneos/flutter_qq/flutter_qq.framework/Headers/flutter_qq-umbrella.h:13:
     build/ios/Release-iphoneos/flutter_qq/flutter_qq.framework/Headers/FlutterQqPlugin.h:2:9: error: include of non-modular header inside
    framework module 'flutter_qq.FlutterQqPlugin': ' ios/Pods/QQSDK/framework/TencentOpenAPI.framework/Headers/TencentOAuth.h'
    [-Werror,-Wnon-modular-include-in-framework-module]
    #import <TencentOpenAPI/TencentOAuth.h>
            ^
     build/ios/Release-iphoneos/flutter_qq/flutter_qq.framework/Headers/FlutterQqPlugin.h:3:9: error: include of non-modular header inside
    framework module 'flutter_qq.FlutterQqPlugin': ' ios/Pods/QQSDK/framework/TencentOpenAPI.framework/Headers/QQApiInterface.h'
    [-Werror,-Wnon-modular-include-in-framework-module]
    #import <TencentOpenAPI/QQApiInterface.h>
            ^
     build/ios/Release-iphoneos/flutter_qq/flutter_qq.framework/Headers/FlutterQqPlugin.h:4:9: error: include of non-modular header inside
    framework module 'flutter_qq.FlutterQqPlugin': ' ios/Pods/QQSDK/framework/TencentOpenAPI.framework/Headers/QQApiInterfaceObject.h'
    [-Werror,-Wnon-modular-include-in-framework-module]
    #import <TencentOpenAPI/QQApiInterfaceObject.h>
            ^
    3 errors generated.
     ios/Runner/GeneratedPluginRegistrant.m:9:9: fatal error: could not build module 'flutter_qq'
    #import <flutter_qq/FlutterQqPlugin.h>`